### PR TITLE
fix page load speed and issue when multiple expense accounts exist

### DIFF
--- a/grantfinancialsupport.php
+++ b/grantfinancialsupport.php
@@ -83,11 +83,15 @@ function grantfinancialsupport_civicrm_buildForm($formName, &$form) {
 
     //Financial Type RG-125
     $financialType = CRM_Contribute_PseudoConstant::financialType();
-    foreach ($financialType as $id => $dontCare) {
-      if (!CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($id, ['IN' => ['Grant Expense Account is', 'Expense Account is']])) {
-        unset($financialType[$id]);
-      }
+    $result = civicrm_api3('EntityFinancialAccount', 'get', [
+      'account_relationship' => ['IN' => ["Expense Account is", "Grant Expense Account is"]],
+      'entity_table' => "civicrm_financial_type",
+      'options' => ['limit' => 0],
+    ])['values'];
+    foreach ($result as $k => $v) {
+      $typesWithExpenseAccounts[$v['entity_id']] = 1;
     }
+    $financialType = array_intersect_key($financialType, $typesWithExpenseAccounts);
     if (count($financialType)) {
       $form->assign('financialType', $financialType);
     }


### PR DESCRIPTION
I first started troubleshooting because the "New Grant" page was taking 20 seconds to load.  I zeroed in on `CRM_Contribute_PseudoConstant::getRelationalFinancialAccount` as the cause of the performance hit - I have ~1700 financial types that need checking.

On closer examination, I saw that this code also has a bug.  It will remove any financial type that has both an "Expense Account" and "Grant Expense Account".  That's because [this line](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contribute/PseudoConstant.php#L405) expects `$result['id']` to exist - which is only true if your `get` returns only a single record.  So the function returns `null` and the extension removes the financial type from the select list.

I encourage QA if you're using this with other clients - but this got my page load from ~20 seconds to ~740ms.  It also fixes the logic error I mentioned.